### PR TITLE
Ensure content tables exist on startup

### DIFF
--- a/services/content-svc/app/main.py
+++ b/services/content-svc/app/main.py
@@ -46,6 +46,9 @@ class Education(Base):
     institution = Column(String)
     years = Column(String)
 
+# Ensure tables are created if they do not yet exist.
+Base.metadata.create_all(bind=engine)
+
 app = FastAPI()
 
 def get_db():


### PR DESCRIPTION
## Summary
- create missing tables for content service on startup to avoid missing-table errors

## Testing
- `python -m py_compile services/content-svc/app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689909829030832ba71872bf0e4920f6