### PR TITLE
Add DevOps-themed landing page and editable summary

### DIFF
--- a/apps/web-frontend/pages/index.tsx
+++ b/apps/web-frontend/pages/index.tsx
@@ -27,6 +27,10 @@ export default function Home({ projects, skills, experience, achievements, educa
   }, [])
 
   const [status, setStatus] = useState<string | null>(null)
+  const [summary, setSummary] = useState(
+    'DevOps engineer with 3 years of experience in automation, CI/CD, Kubernetes and cloud security.'
+  )
+  const [editingSummary, setEditingSummary] = useState(false)
   const submit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const form = e.currentTarget
@@ -48,20 +52,65 @@ export default function Home({ projects, skills, experience, achievements, educa
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <Button onClick={() => document.documentElement.classList.toggle('dark')} className="absolute top-4 right-4">Toggle</Button>
-      <section className="h-screen flex flex-col items-center justify-center text-center">
-        <motion.h1 className="text-4xl font-bold" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-          Khangesh Matte
+      <section
+        className="h-screen flex flex-col items-center justify-center text-center bg-cover bg-center"
+        style={{ backgroundImage: "url('/devops-bg.svg')" }}
+      >
+        <motion.h1
+          className="text-4xl font-bold bg-black/50 px-4 py-2 rounded"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+        >
+          Khangesh Matte - DevOps Engineer
         </motion.h1>
-        <p className="mt-2">DevOps Engineer | Automation | Cloud | CI/CD</p>
+        <p className="mt-2 bg-black/50 px-4 py-1 rounded">Automation | Cloud | CI/CD</p>
         <div className="mt-4 flex gap-4">
-          <a href="/cv.pdf"><Button>Download CV</Button></a>
-          <a href="https://www.linkedin.com" target="_blank" rel="noopener" className="underline">LinkedIn</a>
-          <a href="mailto:khangesh@example.com" className="underline">Email</a>
+          <a href="/cv.pdf" target="_blank" rel="noopener">
+            <Button>View CV</Button>
+          </a>
+          <a href="https://www.linkedin.com" target="_blank" rel="noopener" className="underline">
+            LinkedIn
+          </a>
+          <a href="mailto:khangesh@example.com" className="underline">
+            Email
+          </a>
         </div>
       </section>
       <section id="summary" className="p-8 bg-gray-100 dark:bg-gray-800">
         <h2 className="text-2xl mb-4">Summary</h2>
-        <p>DevOps engineer with 3 years of experience in automation, CI/CD, Kubernetes and cloud security.</p>
+        {editingSummary ? (
+          <form
+            onSubmit={e => {
+              e.preventDefault()
+              setEditingSummary(false)
+            }}
+            className="flex flex-col gap-2"
+          >
+            <textarea
+              className="p-2 border rounded bg-white text-gray-900"
+              value={summary}
+              onChange={e => setSummary(e.target.value)}
+              rows={4}
+            />
+            <div className="flex gap-2">
+              <Button type="submit">Save</Button>
+              <Button
+                type="button"
+                className="bg-gray-500 hover:bg-gray-600"
+                onClick={() => setEditingSummary(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <>
+            <p>{summary}</p>
+            <Button className="mt-2" onClick={() => setEditingSummary(true)}>
+              Edit
+            </Button>
+          </>
+        )}
       </section>
       <section id="skills" className="p-8">
         <h2 className="text-2xl mb-4">Skills</h2>

--- a/apps/web-frontend/public/cv.pdf
+++ b/apps/web-frontend/public/cv.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 100 700 Td (Khangesh Matte CV) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000219 00000 n 
+0000000313 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+373
+%%EOF

--- a/apps/web-frontend/public/devops-bg.svg
+++ b/apps/web-frontend/public/devops-bg.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4F46E5"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="200" fill="url(#grad)"/>
+  <path d="M50 100 C50 50,150 50,150 100 S250 150,250 100 C250 50,350 50,350 100 S250 150,250 100 S150 50,150 100 S50 150,50 100" fill="none" stroke="#ffffff" stroke-width="15" stroke-linecap="round"/>
+  <text x="120" y="115" font-size="40" font-family="sans-serif" font-weight="bold" fill="#ffffff">CI</text>
+  <text x="260" y="115" font-size="40" font-family="sans-serif" font-weight="bold" fill="#ffffff">CD</text>
+</svg>


### PR DESCRIPTION
## Summary
- Use a DevOps CI/CD graphic as the hero background and highlight Khangesh Matte as DevOps Engineer
- Fix CV link by bundling a placeholder `cv.pdf`
- Allow editing the summary section directly on the page

## Testing
- `npm run build` *(hangs at "Collecting page data"; log shows compilation succeeded up to that step)*

------