### PR TITLE
feat: add profile data and cv placeholder

### DIFF
--- a/apps/web-frontend/data/profile.ts
+++ b/apps/web-frontend/data/profile.ts
@@ -1,0 +1,5 @@
+export const profile = {
+  name: "Khangesh Matte",
+  title: "DevOps Engineer | Automation | Cloud | CI/CD",
+  summary: "DevOps engineer with 3 years of experience in automation, CI/CD, Kubernetes and cloud security."
+};

--- a/apps/web-frontend/pages/index.tsx
+++ b/apps/web-frontend/pages/index.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from 'next'
 import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { Button } from '../components/ui/button'
+import { profile } from '../data/profile'
 
 type Project = { id: number; title: string; description: string; tech: string }
 type Skill = { id: number; name: string; category: string }
@@ -48,11 +49,14 @@ export default function Home({ projects, skills, experience, achievements, educa
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <Button onClick={() => document.documentElement.classList.toggle('dark')} className="absolute top-4 right-4">Toggle</Button>
-      <section className="h-screen flex flex-col items-center justify-center text-center">
+      <section
+        className="relative flex flex-col items-center justify-center text-center py-20 bg-cover bg-center"
+        style={{ backgroundImage: "url('/devops-bg.svg')" }}
+      >
         <motion.h1 className="text-4xl font-bold" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-          Khangesh Matte
+          {profile.name}
         </motion.h1>
-        <p className="mt-2">DevOps Engineer | Automation | Cloud | CI/CD</p>
+        <p className="mt-2">{profile.title}</p>
         <div className="mt-4 flex gap-4">
           <a href="/cv.pdf"><Button>Download CV</Button></a>
           <a href="https://www.linkedin.com" target="_blank" rel="noopener" className="underline">LinkedIn</a>
@@ -61,7 +65,7 @@ export default function Home({ projects, skills, experience, achievements, educa
       </section>
       <section id="summary" className="p-8 bg-gray-100 dark:bg-gray-800">
         <h2 className="text-2xl mb-4">Summary</h2>
-        <p>DevOps engineer with 3 years of experience in automation, CI/CD, Kubernetes and cloud security.</p>
+        <p>{profile.summary}</p>
       </section>
       <section id="skills" className="p-8">
         <h2 className="text-2xl mb-4">Skills</h2>

--- a/apps/web-frontend/public/cv.pdf
+++ b/apps/web-frontend/public/cv.pdf
@@ -1,0 +1,71 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 177>>
+stream
+x]=0w~ō҂TV11{/C*&yr B,5f[SB~]#TPLָ+7=Oo_E2%$!){]\rGD
+~-t1&c[:N<,=%-ūz0ÐUγ}D
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+6 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20250811113119)
+>>
+endobj
+7 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000334 00000 n 
+0000000517 00000 n 
+0000000009 00000 n 
+0000000087 00000 n 
+0000000421 00000 n 
+0000000621 00000 n 
+0000000730 00000 n 
+trailer
+<<
+/Size 8
+/Root 7 0 R
+/Info 6 0 R
+>>
+startxref
+833
+%%EOF

--- a/apps/web-frontend/public/devops-bg.svg
+++ b/apps/web-frontend/public/devops-bg.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0f172a;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#1e293b;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="200" fill="url(#grad)"/>
+  <text x="50%" y="50%" fill="#fff" font-size="32" dominant-baseline="middle" text-anchor="middle">DevOps CI/CD</text>
+</svg>


### PR DESCRIPTION
## Summary
- add editable profile data for name, title, and summary
- display devops-themed background image on landing page
- add placeholder CV to fix 404 download link

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d3c9d7b8832b80330580a808d210